### PR TITLE
Use isomorphic websockets library

### DIFF
--- a/dist/logger.d.ts
+++ b/dist/logger.d.ts
@@ -1,0 +1,4 @@
+export declare const debug: (...args: any[]) => void;
+export declare const info: (...args: any[]) => void;
+export declare const warn: (...args: any[]) => void;
+export declare const error: (...args: any[]) => void;

--- a/dist/logger.js
+++ b/dist/logger.js
@@ -1,0 +1,6 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.debug = (...args) => console.debug(...args);
+exports.info = (...args) => console.info(...args);
+exports.warn = (...args) => console.warn(...args);
+exports.error = (...args) => console.error(...args);

--- a/dist/logger.js
+++ b/dist/logger.js
@@ -1,6 +1,11 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.debug = (...args) => console.debug(...args);
-exports.info = (...args) => console.info(...args);
-exports.warn = (...args) => console.warn(...args);
-exports.error = (...args) => console.error(...args);
+let LOGGER_ENABLED = process.env.NODE_ENV != 'test';
+exports.debug = (...args) => { if (LOGGER_ENABLED)
+    console.debug(...args); };
+exports.info = (...args) => { if (LOGGER_ENABLED)
+    console.info(...args); };
+exports.warn = (...args) => { if (LOGGER_ENABLED)
+    console.warn(...args); };
+exports.error = (...args) => { if (LOGGER_ENABLED)
+    console.error(...args); };

--- a/dist/stream-sea-client.js
+++ b/dist/stream-sea-client.js
@@ -1,9 +1,16 @@
 "use strict";
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const events_1 = require("events");
 const stream_sea_connection_1 = require("./stream-sea-connection");
 const utils_1 = require("./utils");
-const logger = require('logacious')();
+const logger = __importStar(require("./logger"));
 /**
  * A StreamSeaClient manages a StreamSeaConnection, restarting it if necessary
  *

--- a/dist/stream-sea-connection.js
+++ b/dist/stream-sea-connection.js
@@ -48,7 +48,8 @@ class StreamSeaConnection extends events_1.EventEmitter {
                 this.emit('error', err);
             });
         };
-        this.onSocketMessage = (msgStr) => {
+        this.onSocketMessage = (msgEvent) => {
+            const msgStr = msgEvent.data;
             let msg;
             try {
                 msg = JSON.parse(msgStr);

--- a/dist/stream-sea-socket.js
+++ b/dist/stream-sea-socket.js
@@ -1,9 +1,6 @@
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-const ws_1 = __importDefault(require("ws"));
+const WebSocket = require('isomorphic-ws');
 const events_1 = require("events");
 const PING_INTERVAL_MS = 15000; // Interval for ping messages in milliseconds
 /**
@@ -49,7 +46,7 @@ class StreamSeaSocket extends events_1.EventEmitter {
             this.ws.send(message);
         };
         this.options = options;
-        this.ws = new ws_1.default(this.options.url);
+        this.ws = new WebSocket(this.options.url);
         this.ws.on('open', this.onWsOpen);
         this.ws.on('message', this.onWsMessage);
         this.ws.on('close', this.onWsClose);

--- a/dist/stream-sea-socket.js
+++ b/dist/stream-sea-socket.js
@@ -20,9 +20,12 @@ class StreamSeaSocket extends events_1.EventEmitter {
         super();
         this.onWsOpen = () => {
             this.heartbeatInterval = setInterval(() => {
-                this.ws.ping(() => {
-                    return;
-                });
+                // this.ws.ping is available on Nodejs but not in the browser
+                if (this.ws.ping) {
+                    this.ws.ping(() => {
+                        return;
+                    });
+                }
             }, PING_INTERVAL_MS);
             this.emit('open');
         };
@@ -47,10 +50,10 @@ class StreamSeaSocket extends events_1.EventEmitter {
         };
         this.options = options;
         this.ws = new WebSocket(this.options.url);
-        this.ws.on('open', this.onWsOpen);
-        this.ws.on('message', this.onWsMessage);
-        this.ws.on('close', this.onWsClose);
-        this.ws.on('error', this.onWsError);
+        this.ws.onopen = this.onWsOpen;
+        this.ws.onmessage = this.onWsMessage;
+        this.ws.onclose = this.onWsClose;
+        this.ws.onerror = this.onWsError;
     }
 }
 exports.StreamSeaSocket = StreamSeaSocket;

--- a/dist/tests/stream-sea-connection.test.js
+++ b/dist/tests/stream-sea-connection.test.js
@@ -18,35 +18,41 @@ class BasicSocket extends events_1.EventEmitter {
             m => {
                 expect(m.action).toBe('authenticate');
                 if (m.payload.password === 'test_app_secret') {
-                    this.emit('message', JSON.stringify({
-                        id: m.id,
-                        action: 'authenticate',
-                        success: true,
-                        payload: {
-                            jailId: 'some_jail',
-                        },
-                    }));
+                    this.emit('message', {
+                        data: JSON.stringify({
+                            id: m.id,
+                            action: 'authenticate',
+                            success: true,
+                            payload: {
+                                jailId: 'some_jail',
+                            },
+                        }),
+                    });
                 }
                 else {
-                    this.emit('message', JSON.stringify({
-                        id: m.id,
-                        action: 'authenticate',
-                        success: false,
-                        error: {
-                            message: 'Invalid credentials',
-                        },
-                    }));
+                    this.emit('message', {
+                        data: JSON.stringify({
+                            id: m.id,
+                            action: 'authenticate',
+                            success: false,
+                            error: {
+                                message: 'Invalid credentials',
+                            },
+                        }),
+                    });
                 }
             },
             m => {
                 expect(m.action).toBe('subscribe');
                 this.subscriptionKey = m.id;
-                this.emit('message', JSON.stringify({
-                    id: m.id,
-                    action: 'subscription',
-                    success: true,
-                    payload: m.id,
-                }));
+                this.emit('message', {
+                    data: JSON.stringify({
+                        id: m.id,
+                        action: 'subscription',
+                        success: true,
+                        payload: m.id,
+                    }),
+                });
             },
         ];
         this.send = (m) => {
@@ -58,14 +64,16 @@ class BasicSocket extends events_1.EventEmitter {
     }
     emitSubscriptionMessage() {
         assert.ok(this.subscriptionKey);
-        this.emit('message', JSON.stringify({
-            id: this.subscriptionKey,
-            action: 'subscription',
-            streamName: 'testStream',
-            payload: {
-                foo: 'bar',
-            },
-        }));
+        this.emit('message', {
+            data: JSON.stringify({
+                id: this.subscriptionKey,
+                action: 'subscription',
+                streamName: 'testStream',
+                payload: {
+                    foo: 'bar',
+                },
+            })
+        });
     }
 }
 class BasicSocketFactory {

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,4 +1,0 @@
-const logger = require('logacious')()
-
-// Disable logacious logging
-logger.disable()

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@types/request-promise-native": "^1.0.17",
     "@types/ws": "^7.2.0",
+    "isomorphic-ws": "^4.0.1",
     "logacious": "^0.4.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@types/request-promise-native": "^1.0.17",
     "@types/ws": "^7.2.0",
     "isomorphic-ws": "^4.0.1",
-    "logacious": "^0.4.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.8",
     "ws": "^7.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-sea-client",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,6 @@
-export const debug = (...args: any[]) => console.debug(...args)
-export const info = (...args: any[]) => console.info(...args)
-export const warn = (...args: any[]) => console.warn(...args)
-export const error = (...args: any[]) => console.error(...args)
+let LOGGER_ENABLED = process.env.NODE_ENV != 'test'
+
+export const debug = (...args: any[]) => {if (LOGGER_ENABLED) console.debug(...args)}
+export const info = (...args: any[]) => {if (LOGGER_ENABLED) console.info(...args)}
+export const warn = (...args: any[]) => {if (LOGGER_ENABLED) console.warn(...args)}
+export const error = (...args: any[]) => {if (LOGGER_ENABLED) console.error(...args)}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,4 @@
+export const debug = (...args: any[]) => console.debug(...args)
+export const info = (...args: any[]) => console.info(...args)
+export const warn = (...args: any[]) => console.warn(...args)
+export const error = (...args: any[]) => console.error(...args)

--- a/src/stream-sea-client.ts
+++ b/src/stream-sea-client.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events'
 import { IStreamSeaConnectionFactory, IStreamSeaConnection, StreamSeaConnectionFactory, StreamSeaConnectionError, StreamSeaConnectionWarning } from './stream-sea-connection'
 import { IStreamSeaSubscription } from './stream-sea-subscription'
 import { getWsURLScheme } from './utils'
-const logger = require('logacious')()
+import * as logger from './logger'
 
 interface StreamSeaClientOptions {
   remoteServerHost: string

--- a/src/stream-sea-connection.ts
+++ b/src/stream-sea-connection.ts
@@ -106,7 +106,8 @@ export class StreamSeaConnection extends EventEmitter implements IStreamSeaConne
       })
   }
 
-  private onSocketMessage = (msgStr: string) => {
+  private onSocketMessage = (msgEvent: MessageEvent) => {
+    const msgStr: string = msgEvent.data
     let msg: any
     try {
       msg = JSON.parse(msgStr)

--- a/src/stream-sea-socket.ts
+++ b/src/stream-sea-socket.ts
@@ -11,6 +11,15 @@ interface StreamSeaSocketOptions {
   url: string
 }
 
+interface IsomorphicWebsocket {
+  onopen: null | (() => void)
+  onmessage: null | ((m: MessageEvent) => void)
+  onclose: null | (() => void)
+  onerror: null | ((e: any) => void)
+  ping?: (callback: () => void) => void
+  send: (message: string) => void
+}
+
 /**
  * A StreamSeaSocket encapsulates a WebSocket with automatic ping-pong.
  *
@@ -24,7 +33,7 @@ interface StreamSeaSocketOptions {
  *   send(message: string)
  */
 export class StreamSeaSocket extends EventEmitter implements IStreamSeaSocket {
-  private ws: any
+  private ws: IsomorphicWebsocket
   private heartbeatInterval?: NodeJS.Timeout
   private options: StreamSeaSocketOptions
   constructor(options: StreamSeaSocketOptions) {
@@ -49,7 +58,7 @@ export class StreamSeaSocket extends EventEmitter implements IStreamSeaSocket {
     this.emit('open')
   }
 
-  private onWsMessage = (m: any) => {
+  private onWsMessage = (m: MessageEvent) => {
     // console.log('StreamSeaSocket.onWsMessage:', JSON.stringify(m, null, 4))
     this.emit('message', m)
   }

--- a/src/stream-sea-socket.ts
+++ b/src/stream-sea-socket.ts
@@ -31,17 +31,20 @@ export class StreamSeaSocket extends EventEmitter implements IStreamSeaSocket {
     super()
     this.options = options
     this.ws = new WebSocket(this.options.url)
-    this.ws.on('open', this.onWsOpen)
-    this.ws.on('message', this.onWsMessage)
-    this.ws.on('close', this.onWsClose)
-    this.ws.on('error', this.onWsError)
+    this.ws.onopen = this.onWsOpen
+    this.ws.onmessage = this.onWsMessage
+    this.ws.onclose = this.onWsClose
+    this.ws.onerror = this.onWsError
   }
 
   private onWsOpen = () => {
     this.heartbeatInterval = setInterval(() => {
-      this.ws.ping(() => {
-        return
-      })
+      // this.ws.ping is available on Nodejs but not in the browser
+      if (this.ws.ping){
+        this.ws.ping(() => {
+          return
+        })
+      }
     }, PING_INTERVAL_MS)
     this.emit('open')
   }

--- a/src/stream-sea-socket.ts
+++ b/src/stream-sea-socket.ts
@@ -1,4 +1,4 @@
-import WebSocket from 'ws'
+const WebSocket = require('isomorphic-ws')
 import { EventEmitter } from 'events'
 
 const PING_INTERVAL_MS = 15000 // Interval for ping messages in milliseconds
@@ -24,7 +24,7 @@ interface StreamSeaSocketOptions {
  *   send(message: string)
  */
 export class StreamSeaSocket extends EventEmitter implements IStreamSeaSocket {
-  private ws: WebSocket
+  private ws: any
   private heartbeatInterval?: NodeJS.Timeout
   private options: StreamSeaSocketOptions
   constructor(options: StreamSeaSocketOptions) {

--- a/src/tests/stream-sea-connection.test.ts
+++ b/src/tests/stream-sea-connection.test.ts
@@ -13,26 +13,30 @@ class BasicSocket extends EventEmitter implements IStreamSeaSocket {
       if (m.payload.password === 'test_app_secret') {
         this.emit(
           'message',
-          JSON.stringify({
-            id: m.id,
-            action: 'authenticate',
-            success: true,
-            payload: {
-              jailId: 'some_jail',
-            },
-          })
+          {
+            data: JSON.stringify({
+              id: m.id,
+              action: 'authenticate',
+              success: true,
+              payload: {
+                jailId: 'some_jail',
+              },
+            }),
+          }
         )
       } else {
         this.emit(
           'message',
-          JSON.stringify({
-            id: m.id,
-            action: 'authenticate',
-            success: false,
-            error: {
-              message: 'Invalid credentials',
-            },
-          })
+          {
+            data: JSON.stringify({
+              id: m.id,
+              action: 'authenticate',
+              success: false,
+              error: {
+                message: 'Invalid credentials',
+              },
+            }),
+          }
         )
       }
     },
@@ -41,12 +45,14 @@ class BasicSocket extends EventEmitter implements IStreamSeaSocket {
       this.subscriptionKey = m.id
       this.emit(
         'message',
-        JSON.stringify({
-          id: m.id,
-          action: 'subscription',
-          success: true,
-          payload: m.id,
-        })
+        {
+          data: JSON.stringify({
+            id: m.id,
+            action: 'subscription',
+            success: true,
+            payload: m.id,
+          }),
+        }
       )
     },
   ]
@@ -63,14 +69,16 @@ class BasicSocket extends EventEmitter implements IStreamSeaSocket {
     assert.ok(this.subscriptionKey)
     this.emit(
       'message',
-      JSON.stringify({
-        id: this.subscriptionKey,
-        action: 'subscription',
-        streamName: 'testStream',
-        payload: {
-          foo: 'bar',
-        },
-      })
+      {
+        data: JSON.stringify({
+          id: this.subscriptionKey,
+          action: 'subscription',
+          streamName: 'testStream',
+          payload: {
+            foo: 'bar',
+          },
+        })
+      }
     )
   }
 }


### PR DESCRIPTION
This PR makes stream-sea-client-node suitable for browser use:
  - Remove dependency on logacious which has Nodejs-only dependencies
  - Use `isomorphic-ws` instead of `ws` as the websockets library

Note: client WS ping is disabled in the browser as there is no such API. We will have to implement server ping in the stream-sea server instead.

## Manual testing
### Node
- Link stream-sea-cli project against stream-sea-client-node with this PR
- Run the `subscribe` command and verify messages are streamed to the CLI
### Browser
- Link hello-stream-sea project against stream-sea-client-node with this PR
- Run the hello-stream-sea app in dev mode and verify that messages are streamed to the browser console
### DX
- Run unit tests and verify that no error messages are printed to the console (and thus the logacious replacement is working correctly)