### PR TITLE
CI should fail if build artifacts are stale

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           steps:
             - run: npm install
             - run: npm run build
-            - run: if [[ $(git diff) ]]; then echo "Build output does not match checked-in assets"; exit 1; fi;
+            - run: if [[ $(git diff) ]]; then echo "Build output does not match checked-in assets"; git diff; exit 1; fi;
             - run: npm test
 workflows:
     build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             # However, some type declarations may differ between minor compiler versions due to a typescript issue: https://github.com/microsoft/TypeScript/issues/17944
             # Therefore we exclude type declarations from the 'git diff' comparison
             # When the typescript issue is resolved, we can just use 'git diff'
-            - run: if [[ $(git diff -- . ':(exclude)dist/**/*.d.ts') ]]; then echo "Build output does not match checked-in assets"; git diff -- . ':(exclude)dist/**/*.d.ts'; exit 1; fi;
+            - run: if [[ $(git diff -- . ':(exclude)**/*.d.ts') ]]; then echo "Build output does not match checked-in assets"; git diff -- . ':(exclude)**/*.d.ts'; exit 1; fi;
             - run: npm test
 workflows:
     build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,11 @@ jobs:
           steps:
             - run: npm install
             - run: npm run build
-            - run: if [[ $(git diff) ]]; then echo "Build output does not match checked-in assets"; git diff; exit 1; fi;
+            # We want to compare the CI build output against the checked-in build output
+            # However, some type declarations may differ between minor compiler versions due to a typescript issue: https://github.com/microsoft/TypeScript/issues/17944
+            # Therefore we exclude type declarations from the 'git diff' comparison
+            # When the typescript issue is resolved, we can just use 'git diff'
+            - run: if [[ $(git diff -- . ':(exclude)dist/**/*.d.ts') ]]; then echo "Build output does not match checked-in assets"; git diff -- . ':(exclude)dist/**/*.d.ts'; exit 1; fi;
             - run: npm test
 workflows:
     build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ jobs:
       - node/with-cache:
           steps:
             - run: npm install
+            - run: npm run build
+            - run: if [[ $(git diff) ]]; then echo "Build output does not match checked-in assets"; exit 1; fi;
             - run: npm test
 workflows:
     build-and-test:


### PR DESCRIPTION
This PR adds a CI check that the checked-in JS files are consistent with TS files.

### Manual testing
- Create a branch with TS changes but missing the associated JS changes. Here is an example: https://github.com/Portchain/stream-sea-client-node/tree/demo_stale_branch
- Verify that CI fails for that branch.