### PR TITLE
JWT authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,25 @@ This library is compatible with stream-sea ^2.1 (i.e. 2.1 <= stream-sea < 3.0)
 - The protocol is initiated by the client establishing a Websocket connection to the server
 - As long as the Websocket connection is open, it is the server's responsibility to send Websocket ping messages
 at least every 30 seconds to avoid idle connections being closed
-- Once a connection is established, the client and server communicate by exchanging *stream-sea wire messages*, also known in this spec as *wire messages* or just *messages*.
-- Every wire message is a JSON object
-- The stream-sea server and stream-sea client can send a stream-sea wire message `m` by serializing it to a string `s = JSON.stringify(m)`
- and then sending a Websocket data message with payload `s`
+- Once a connection is established, the client and server communicate by exchanging Websocket data messages, which will be referred to as just *messages* for the rest of this spec.
+- Every message is a JSON object serialized to a string
 
-### Wire message structure
-- Each wire message has an `id` field of JSON type `number` and a `action` field of JSON type `string`
+### Message structure
+- Each message has an `id` field of JSON type `number` and a `action` field of JSON type `string`. Here is an example message:
+```
+{
+	"id": 2,
+	"action": "subscription",
+	"streamName": "boiler_data",
+	"payload": {
+		"temperature": 92,
+		"pressure": 3002
+	}
+}
+```
 - The client must send the first message with `id` equal to `1`, and must increase `id` by 1 for each subsequent message
-- Each wire message `x` sent by the server is a response to an earlier wire message `y` sent by the client. `x` must have the same values of `id` and `action` as `y`
-- For some wire messages `y` sent by the client, the server can reply with multiple wire messages `x1, x2, ...`. These must all have the same values of `id` and `action` as `y`
+- Each message `x` sent by the server is a response to an earlier message `y` sent by the client. `x` must have the same values of `id` and `action` as `y`
+- For some messages `y` sent by the client, the server can reply with multiple messages `x1, x2, ...`. These must all have the same values of `id` and `action` as `y`
 
 ### Authentication Request Message
 - The client-sent message with `id = 1` must be an Authentication Request message

--- a/README.md
+++ b/README.md
@@ -1,24 +1,84 @@
 An isomorphic client library for stream-sea
 
-### Compatibility
-This library is compatible with stream-sea ^2.0 (i.e. 2.0 <= stream-sea < 3.0)
+# Compatibility
+This library is compatible with stream-sea ^2.1 (i.e. 2.1 <= stream-sea < 3.0)
 
-### For users
+# For users
 
-### For developers
+# For developers
 
-Here is an example of a stream sea socket protocol conversation.
+## Stream-sea wire protocol
+
+### Websocket layer
+- The stream-sea wire protocol is built on top of the Websocket protocol
+- The protocol is initiated by the client establishing a Websocket connection to the server
+- As long as the Websocket connection is open, it is the server's responsibility to send Websocket ping messages
+at least every 30 seconds to avoid idle connections being closed
+- Once a connection is established, the client and server communicate by exchanging *stream-sea wire messages*, also known in this spec as *wire messages* or just *messages*.
+- Every wire message is a JSON object
+- The stream-sea server and stream-sea client can send a stream-sea wire message `m` by serializing it to a string `s = JSON.stringify(m)`
+ and then sending a Websocket data message with payload `s`
+
+### Wire message structure
+- Each wire message has an `id` field of JSON type `number` and a `action` field of JSON type `string`
+- The client must send the first message with `id` equal to `1`, and must increase `id` by 1 for each subsequent message
+- Each wire message `x` sent by the server is a response to an earlier wire message `y` sent by the client. `x` must have the same values of `id` and `action` as `y`
+- For some wire messages `y` sent by the client, the server can reply with multiple wire messages `x1, x2, ...`. These must all have the same values of `id` and `action` as `y`
+
+### Authentication Request Message
+- The client-sent message with `id = 1` must be an Authentication Request message
+- Client-sent messages with `id > 1` must not be Authentication Request messages
+- An Authentication Request message has an `action` field with value `"authenticate"`
+- An Authentication Request message must have a `payload` field of JSON type `object`
+- Stream-sea supports two authentication methods: Basic and JWT
+- In order to authenticate with the Basic method, the `payload` of the Authentication Request message must have the following fields:
+  - A `type` field with value `"basic"`
+  - A `clientId` field of JSON type `string`
+  - A `clientSecret` field of JSON type `string`
+- In order to authenticate with the Basic method, the `payload` of the Authentication Request message must have the following fields:
+  - A `type` field with value `"jwt"`
+  - A `clientId` field of JSON type `string`
+  - A `jwt` field of JSON type `string` containing the stream-sea JWT that is signed and serialized using the client JWT secret and RFC 7515 JWS Compact Serialization
+- The server must respond to an Authentication Request message with exactly one Authentication Response message
+
+### Stream-sea JWT
+- The stream-sea JWT is a JSON object
+- The stream-sea JWT must have an `exp` field of JSON type `number`. This must contain the expiration time as a UNIX timestamp as per RFC 7515
+- The stream-sea JWT must have an `mustFanout` field of JSON type `boolean`. If true, the client must use fanout mode for all subscriptions.
+
+### Authentication Response Message
+- An Authentication Response message has an `action` field with value `"authenticate"`
+- An Authentication Response message must have a `success` field of JSON type `boolean` which will indicate whether authentication was successful
+- If authentication was unsuccessful, the client must close the connection and must not send any more messages
+
+### Subscription Request Message
+- The client may subscribe by sending a Subscription Request message
+- A Subscription Request message has an `action` field with value `"subscribe"`
+- A Subscription Request message has a `payload` field of JSON type `string`. The value of this field must be the name of the stream to subscribe to.
+- A Subscription Request message may have a `groupId` field of JSON type `string`. If set, the value of this field must be a UUID in RFC 4122 format (also known as the 8-4-4-4-12 format).
+- A Subscription Request message may have multiple responses. The first response must be a Subscription Response message. Each subsequent response must be a Message Delivery message.
+
+### Subscription Response Message
+- A Subscription Response message has an `action` field with value `"subscribe"`
+- A Subscription Response message has a `streamName` field of JSON type `string`. The value of this field is the name of the stream that was subscribed to.
+
+### Message Delivery
+- A Message Delivery message has an `action` field with value `"subscribe"`
+- A Message Delivery message has a `payload` field of JSON type `object`. This value of this field is the user-defined message object.
+
+### Example of stream-sea wire protocol exchange
 
 The client authenticates and subscribes to the stream `boiler_data`
-The server sends one message for the subscription.
+The server delivers two messages from the `boiler_data` stream.
 
 ```
 StreamSeaSocket.send {
 	"id":1,
 	"action": "authenticate",
 	"payload": {
-		"username": "some_username",
-		"password": "some_password"
+		"type": "basic"
+		"clientId": "abc",
+		"clientSecret": "def123"
 	}
 }
 
@@ -53,6 +113,16 @@ StreamSeaSocket.onWsMessage: {
 	"payload": {
 		"temperature": 91,
 		"pressure": 3001
+	}
+}
+
+StreamSeaSocket.onWsMessage: {
+	"id": 2,
+	"action": "subscription",
+	"streamName": "boiler_data",
+	"payload": {
+		"temperature": 92,
+		"pressure": 3002
 	}
 }
 ```

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,19 +1,32 @@
 import { Stream, Remote, SchemaDefinition } from './types';
 import { StreamSeaSubscription } from './stream-sea-subscription';
 export declare const subscribe: (args: Remote & Stream & {
+    appSecret: string;
+    fanout?: boolean | undefined;
+}) => Promise<StreamSeaSubscription>;
+export declare const subscribeWithJwt: (args: Remote & Stream & {
+    jwt: string;
     fanout?: boolean | undefined;
 }) => Promise<StreamSeaSubscription>;
 export declare const publish: (args: Remote & Stream & {
+    appSecret: string;
     payload: any;
 }) => Promise<any>;
-export declare const defineStream: (args: Remote & Stream & SchemaDefinition) => Promise<any>;
-export declare const describeStream: (args: Remote & Stream & SchemaDefinition) => Promise<any>;
+export declare const defineStream: (args: Remote & Stream & {
+    appSecret: string;
+} & SchemaDefinition) => Promise<any>;
+export declare const describeStream: (args: Remote & Stream & {
+    appSecret: string;
+} & SchemaDefinition) => Promise<any>;
 export declare const createClient: (args: Remote & {
+    appSecret: string;
     description: string;
 }) => Promise<any>;
 export declare const deleteClient: (args: Remote & {
+    appSecret: string;
     clientId: string;
 }) => Promise<any>;
 export declare const rotateClientSecret: (args: Remote & {
+    appSecret: string;
     clientId: string;
 }) => Promise<any>;

--- a/dist/index.js
+++ b/dist/index.js
@@ -9,7 +9,27 @@ const stream_sea_client_1 = require("./stream-sea-client");
 const stream_sea_subscription_1 = require("./stream-sea-subscription");
 const utils_1 = require("./utils");
 exports.subscribe = async (args) => {
-    const client = stream_sea_client_1.getStreamSeaClient(args);
+    const client = stream_sea_client_1.getStreamSeaClient({
+        ...args,
+        credentialOptions: {
+            type: 'secret',
+            appId: args.appId,
+            secret: args.appSecret,
+        }
+    });
+    const subscription = new stream_sea_subscription_1.StreamSeaSubscription(args.stream);
+    client.addSubscription(subscription);
+    return subscription;
+};
+exports.subscribeWithJwt = async (args) => {
+    const client = stream_sea_client_1.getStreamSeaClient({
+        ...args,
+        credentialOptions: {
+            type: 'jwt',
+            appId: args.appId,
+            jwt: args.jwt,
+        },
+    });
     const subscription = new stream_sea_subscription_1.StreamSeaSubscription(args.stream);
     client.addSubscription(subscription);
     return subscription;

--- a/dist/stream-sea-client.d.ts
+++ b/dist/stream-sea-client.d.ts
@@ -2,14 +2,14 @@
 import { EventEmitter } from 'events';
 import { IStreamSeaConnectionFactory } from './stream-sea-connection';
 import { IStreamSeaSubscription } from './stream-sea-subscription';
-interface StreamSeaClientOptions {
+import { CredentialOptions } from './types';
+declare type StreamSeaClientOptions = {
     remoteServerHost: string;
     remoteServerPort: string;
     secure: boolean;
-    appId: string;
-    appSecret: string;
+    credentialOptions: CredentialOptions;
     fanout?: boolean;
-}
+};
 /**
  * A StreamSeaClient manages a StreamSeaConnection, restarting it if necessary
  *

--- a/dist/stream-sea-client.d.ts
+++ b/dist/stream-sea-client.d.ts
@@ -37,6 +37,7 @@ export declare class StreamSeaClient extends EventEmitter {
     private onConnectionClose;
     private reopenConnection;
     addSubscription: (subscription: IStreamSeaSubscription) => void;
+    setCredentialOptions: (credentialOptions: CredentialOptions) => void;
 }
 export declare const getStreamSeaClient: (options: StreamSeaClientOptions) => StreamSeaClient;
 export {};

--- a/dist/stream-sea-client.js
+++ b/dist/stream-sea-client.js
@@ -57,8 +57,7 @@ class StreamSeaClient extends events_1.EventEmitter {
             logger.warn('StreamSeaClient: Reopening connection');
             this.connection = this.options.connectionFactory.createConnection({
                 url: `${utils_1.getWsURLScheme(this.options.secure)}://${this.options.remoteServerHost}:${this.options.remoteServerPort}/api/v1/streams`,
-                appId: this.options.appId,
-                appSecret: this.options.appSecret,
+                credentialOptions: this.options.credentialOptions,
                 fanout: !!this.options.fanout,
             });
             this.attachConnectionEventHandlers();
@@ -71,8 +70,7 @@ class StreamSeaClient extends events_1.EventEmitter {
         this.options = options;
         this.connection = options.connectionFactory.createConnection({
             url: `${utils_1.getWsURLScheme(options.secure)}://${options.remoteServerHost}:${options.remoteServerPort}/api/v1/streams`,
-            appId: options.appId,
-            appSecret: options.appSecret,
+            credentialOptions: options.credentialOptions,
             fanout: !!options.fanout,
         });
         this.attachConnectionEventHandlers();

--- a/dist/stream-sea-client.js
+++ b/dist/stream-sea-client.js
@@ -71,6 +71,9 @@ class StreamSeaClient extends events_1.EventEmitter {
             this.subscriptions.push(subscription);
             this.connection.addSubscription(subscription);
         };
+        this.setCredentialOptions = (credentialOptions) => {
+            this.options.credentialOptions = credentialOptions;
+        };
         this.options = options;
         this.groupId = options.fanout ? uuid_random_1.default() : undefined;
         this.connection = options.connectionFactory.createConnection({

--- a/dist/stream-sea-connection.d.ts
+++ b/dist/stream-sea-connection.d.ts
@@ -2,13 +2,13 @@
 import { EventEmitter } from 'events';
 import { IStreamSeaSubscription } from './stream-sea-subscription';
 import { IStreamSeaSocketFactory } from './stream-sea-socket';
+import { CredentialOptions } from './types';
 export interface IStreamSeaConnection extends EventEmitter {
     addSubscription: (subscription: IStreamSeaSubscription) => void;
 }
 export interface StreamSeaConnectionOptions {
     url: string;
-    appId: string;
-    appSecret: string;
+    credentialOptions: CredentialOptions;
     fanout: boolean;
 }
 export declare enum StreamSeaConnectionStatus {

--- a/dist/stream-sea-connection.js
+++ b/dist/stream-sea-connection.js
@@ -31,10 +31,16 @@ class StreamSeaConnection extends events_1.EventEmitter {
         this.subscriptionsQueue = [];
         this.callbacksMap = new Map();
         this.onSocketOpen = () => {
-            this.sendAndExpectSingleReply('authenticate', {
-                username: this.options.appId,
-                password: this.options.appSecret,
-            })
+            const authPayload = this.options.credentialOptions.type === 'jwt' ? {
+                type: 'jwt',
+                clientId: this.options.credentialOptions.appId,
+                jwt: this.options.credentialOptions.jwt,
+            } : {
+                type: 'secret',
+                username: this.options.credentialOptions.appId,
+                password: this.options.credentialOptions.secret,
+            };
+            this.sendAndExpectSingleReply('authenticate', authPayload)
                 .then(() => {
                 this.emit('open');
                 this.status = StreamSeaConnectionStatus.open;

--- a/dist/tests/stream-sea-client.test.js
+++ b/dist/tests/stream-sea-client.test.js
@@ -63,8 +63,11 @@ describe('StreamSeaClient', () => {
         const mockAddSubscription = jest.fn();
         const connectionFactory = new GoodConnectionFactory(mockAddSubscription);
         const client = new stream_sea_client_1.StreamSeaClient({
-            appId: 'mockId',
-            appSecret: 'mockSecret',
+            credentialOptions: {
+                type: 'secret',
+                appId: 'mockId',
+                secret: 'mockSecret',
+            },
             remoteServerHost: 'mockHost',
             remoteServerPort: '101',
             secure: false,
@@ -85,8 +88,11 @@ describe('StreamSeaClient', () => {
         const mockAddSubscription = jest.fn();
         const connectionFactory = new ThirdTimeLuckyConnectionFactory(mockAddSubscription);
         const client = new stream_sea_client_1.StreamSeaClient({
-            appId: 'mockId',
-            appSecret: 'mockSecret',
+            credentialOptions: {
+                type: 'secret',
+                appId: 'mockId',
+                secret: 'mockSecret',
+            },
             remoteServerHost: 'mockHost',
             remoteServerPort: '101',
             secure: false,

--- a/dist/tests/stream-sea-connection.test.js
+++ b/dist/tests/stream-sea-connection.test.js
@@ -14,11 +14,14 @@ const stream_sea_subscription_1 = require("../stream-sea-subscription");
 class BasicSocket extends events_1.EventEmitter {
     constructor() {
         super();
+        this.verifyAuthenticationPayload = (payload) => {
+            expect(payload.type).toBe('basic');
+            return payload.clientSecret === 'test_client_secret';
+        };
         this.sendCallbacks = [
             m => {
                 expect(m.action).toBe('authenticate');
-                expect(m.payload.type).toBe('basic');
-                if (m.payload.clientSecret === 'test_client_secret') {
+                if (this.verifyAuthenticationPayload(m.payload)) {
                     this.emit('message', {
                         data: JSON.stringify({
                             id: m.id,
@@ -88,8 +91,27 @@ class BasicSocketFactory {
         };
     }
 }
+class JwtSocket extends BasicSocket {
+    constructor() {
+        super(...arguments);
+        this.verifyAuthenticationPayload = (payload) => {
+            expect(payload.type).toBe('jwt');
+            return payload.jwt === 'test.client.jwt';
+        };
+    }
+}
+class JwtSocketFactory {
+    constructor() {
+        this.sockets = [];
+        this.createSocket = () => {
+            const socket = new JwtSocket();
+            this.sockets.push(socket);
+            return socket;
+        };
+    }
+}
 describe('StreamSeaConnection', () => {
-    it('positive: default groupId', done => {
+    it('positive: Basic auth with default groupId', done => {
         const socketFactory = new BasicSocketFactory();
         const connection = new stream_sea_connection_1.StreamSeaConnection({
             url: 'test_url',
@@ -120,7 +142,7 @@ describe('StreamSeaConnection', () => {
             socketFactory.sockets[0].emitSubscriptionMessage();
         }, 1000);
     });
-    it('positive: custom groupId', done => {
+    it('positive: Basic auth with custom groupId', done => {
         const socketFactory = new BasicSocketFactory();
         const connection = new stream_sea_connection_1.StreamSeaConnection({
             url: 'test_url',
@@ -151,7 +173,7 @@ describe('StreamSeaConnection', () => {
             socketFactory.sockets[0].emitSubscriptionMessage();
         }, 1000);
     });
-    it('negative: bad credentials', done => {
+    it('negative: Basic auth with bad credentials', done => {
         const socketFactory = new BasicSocketFactory();
         const connection = new stream_sea_connection_1.StreamSeaConnection({
             url: 'test_url',
@@ -178,6 +200,37 @@ describe('StreamSeaConnection', () => {
             // Verify that the error handler was called
             expect(errorHandler.mock.calls.length).toBe(1);
             done();
+        }, 1000);
+    });
+    it('positive: JWT auth', done => {
+        const socketFactory = new JwtSocketFactory();
+        const connection = new stream_sea_connection_1.StreamSeaConnection({
+            url: 'test_url',
+            credentialOptions: {
+                type: 'jwt',
+                clientId: 'test_client_id',
+                jwt: 'test.client.jwt',
+            },
+            socketFactory,
+            groupId: undefined,
+        });
+        const subscription = new stream_sea_subscription_1.StreamSeaSubscription('testStream');
+        connection.addSubscription(subscription);
+        setTimeout(() => {
+            // Verify a socket was created
+            expect(socketFactory.sockets.length).toBe(1);
+            // Verify the groupId is undefined
+            expect(socketFactory.sockets[0].groupId).toBe(undefined);
+            // Verify that all send callbacks have been called
+            expect(socketFactory.sockets[0].sendCallbacks.length).toBe(0);
+            // Verify that the connection is open
+            expect(connection.status).toBe(stream_sea_connection_1.StreamSeaConnectionStatus.open);
+            // Verify that messages on the socket are forwarded to the subscription
+            subscription.on('message', m => {
+                expect(m.foo).toBe('bar');
+                done();
+            });
+            socketFactory.sockets[0].emitSubscriptionMessage();
         }, 1000);
     });
 });

--- a/dist/tests/stream-sea-connection.test.js
+++ b/dist/tests/stream-sea-connection.test.js
@@ -124,8 +124,11 @@ describe('StreamSeaConnection', () => {
         const socketFactory = new BasicSocketFactory();
         const connection = new stream_sea_connection_1.StreamSeaConnection({
             url: 'test_url',
-            clientId: 'test_client_id',
-            clientSecret: 'test_client_secret',
+            credentialOptions: {
+                type: 'basic',
+                clientId: 'test_client_id',
+                clientSecret: 'test_client_secret',
+            },
             socketFactory,
             groupId: '00000000-0000-0000-000000001234',
         });

--- a/dist/tests/stream-sea-connection.test.js
+++ b/dist/tests/stream-sea-connection.test.js
@@ -91,8 +91,11 @@ describe('StreamSeaConnection', () => {
         const socketFactory = new BasicSocketFactory();
         const connection = new stream_sea_connection_1.StreamSeaConnection({
             url: 'test_url',
-            appId: 'test_app_id',
-            appSecret: 'test_app_secret',
+            credentialOptions: {
+                type: 'secret',
+                appId: 'test_app_id',
+                secret: 'test_app_secret',
+            },
             socketFactory,
             fanout: false,
         });
@@ -117,8 +120,11 @@ describe('StreamSeaConnection', () => {
         const socketFactory = new BasicSocketFactory();
         const connection = new stream_sea_connection_1.StreamSeaConnection({
             url: 'test_url',
-            appId: 'test_app_id',
-            appSecret: 'wrong_secret',
+            credentialOptions: {
+                type: 'secret',
+                appId: 'test_app_id',
+                secret: 'wrong_secret',
+            },
             socketFactory,
             fanout: false,
         });

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -1,6 +1,5 @@
 export interface Remote {
     appId: string;
-    appSecret: string;
     remoteServerHost: string;
     remoteServerPort: string;
     secure: boolean;
@@ -39,3 +38,14 @@ export interface SchemaDefinition extends Schema {
     name: string;
     version: number;
 }
+export declare type SecretCredentialOptions = {
+    type: 'secret';
+    appId: string;
+    secret: string;
+};
+export declare type JwtCredentialOptions = {
+    type: 'jwt';
+    appId: string;
+    jwt: string;
+};
+export declare type CredentialOptions = SecretCredentialOptions | JwtCredentialOptions;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-sea-client",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,35 @@ import { getStreamSeaClient } from './stream-sea-client'
 import { StreamSeaSubscription } from './stream-sea-subscription'
 import { getHttpURLScheme } from './utils'
 
-export const subscribe = async (args: Remote & Stream & {fanout?: boolean}) => {
-  const client = getStreamSeaClient(args)
+export const subscribe = async (args: Remote & Stream & {appSecret: string, fanout?: boolean}) => {
+  const client = getStreamSeaClient({
+    ...args,
+    credentialOptions: {
+      type: 'secret',
+      appId: args.appId,
+      secret: args.appSecret,
+    }
+  })
   const subscription = new StreamSeaSubscription(args.stream)
   client.addSubscription(subscription)
   return subscription
 }
 
-export const publish = async (args: Remote & Stream & { payload: any }) => {
+export const subscribeWithJwt = async (args: Remote & Stream & {jwt: string, fanout?: boolean}) => {
+  const client = getStreamSeaClient({
+    ...args,
+    credentialOptions: {
+      type: 'jwt',
+      appId: args.appId,
+      jwt: args.jwt,
+    },
+  })
+  const subscription = new StreamSeaSubscription(args.stream)
+  client.addSubscription(subscription)
+  return subscription
+}
+
+export const publish = async (args: Remote & Stream & { appSecret: string, payload: any }) => {
   return await request({
     url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/streams/${args.stream}/publish`,
     headers: {
@@ -26,7 +47,7 @@ export const publish = async (args: Remote & Stream & { payload: any }) => {
   })
 }
 
-export const defineStream = async (args: Remote & Stream & SchemaDefinition) => {
+export const defineStream = async (args: Remote & Stream & {appSecret: string} & SchemaDefinition) => {
   return await request({
     url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/streams/${args.stream}/define`,
     headers: {
@@ -40,7 +61,7 @@ export const defineStream = async (args: Remote & Stream & SchemaDefinition) => 
   })
 }
 
-export const describeStream = async (args: Remote & Stream & SchemaDefinition) => {
+export const describeStream = async (args: Remote & Stream & {appSecret: string} & SchemaDefinition) => {
   const a = {
     url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/streams/${args.stream}/schema`,
     headers: {
@@ -54,7 +75,7 @@ export const describeStream = async (args: Remote & Stream & SchemaDefinition) =
   return await request(a)
 }
 
-export const createClient = async (args: Remote & { description: string }) => {
+export const createClient = async (args: Remote & { appSecret: string, description: string }) => {
   return await request({
     url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client`,
     headers: {
@@ -68,7 +89,7 @@ export const createClient = async (args: Remote & { description: string }) => {
   })
 }
 
-export const deleteClient = async (args: Remote & { clientId: string }) => {
+export const deleteClient = async (args: Remote & { appSecret: string, clientId: string }) => {
   return await request({
     url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client/${args.clientId}`,
     headers: {
@@ -81,7 +102,7 @@ export const deleteClient = async (args: Remote & { clientId: string }) => {
   })
 }
 
-export const rotateClientSecret = async (args: Remote & { clientId: string }) => {
+export const rotateClientSecret = async (args: Remote & { appSecret: string, clientId: string }) => {
   return await request({
     url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client/${args.clientId}`,
     headers: {

--- a/src/stream-sea-client.ts
+++ b/src/stream-sea-client.ts
@@ -3,13 +3,13 @@ import { IStreamSeaConnectionFactory, IStreamSeaConnection, StreamSeaConnectionF
 import { IStreamSeaSubscription } from './stream-sea-subscription'
 import { getWsURLScheme } from './utils'
 import * as logger from './logger'
+import { CredentialOptions } from './types'
 
-interface StreamSeaClientOptions {
+type StreamSeaClientOptions = {
   remoteServerHost: string
   remoteServerPort: string
   secure: boolean
-  appId: string
-  appSecret: string
+  credentialOptions: CredentialOptions
   fanout?: boolean
 }
 
@@ -35,8 +35,7 @@ export class StreamSeaClient extends EventEmitter {
     this.options = options
     this.connection = options.connectionFactory.createConnection({
       url: `${getWsURLScheme(options.secure)}://${options.remoteServerHost}:${options.remoteServerPort}/api/v1/streams`,
-      appId: options.appId,
-      appSecret: options.appSecret,
+      credentialOptions: options.credentialOptions,
       fanout: !!options.fanout,
     })
     this.attachConnectionEventHandlers()
@@ -75,8 +74,7 @@ export class StreamSeaClient extends EventEmitter {
     logger.warn('StreamSeaClient: Reopening connection')
     this.connection = this.options.connectionFactory.createConnection({
       url: `${getWsURLScheme(this.options.secure)}://${this.options.remoteServerHost}:${this.options.remoteServerPort}/api/v1/streams`,
-      appId: this.options.appId,
-      appSecret: this.options.appSecret,
+      credentialOptions: this.options.credentialOptions,
       fanout: !!this.options.fanout,
     })
     this.attachConnectionEventHandlers()

--- a/src/stream-sea-client.ts
+++ b/src/stream-sea-client.ts
@@ -87,6 +87,9 @@ export class StreamSeaClient extends EventEmitter {
     this.subscriptions.push(subscription)
     this.connection.addSubscription(subscription)
   }
+  public setCredentialOptions = (credentialOptions: CredentialOptions) => {
+    this.options.credentialOptions = credentialOptions
+  }
 }
 
 export const getStreamSeaClient = (options: StreamSeaClientOptions) => new StreamSeaClient({ ...options, connectionFactory: new StreamSeaConnectionFactory({}) })

--- a/src/tests/stream-sea-client.test.ts
+++ b/src/tests/stream-sea-client.test.ts
@@ -68,8 +68,11 @@ describe('StreamSeaClient', () => {
     const mockAddSubscription = jest.fn()
     const connectionFactory = new GoodConnectionFactory(mockAddSubscription)
     const client = new StreamSeaClient({
-      appId: 'mockId',
-      appSecret: 'mockSecret',
+      credentialOptions: {
+        type: 'secret',
+        appId: 'mockId',
+        secret: 'mockSecret',
+      },
       remoteServerHost: 'mockHost',
       remoteServerPort: '101',
       secure: false,
@@ -91,8 +94,11 @@ describe('StreamSeaClient', () => {
     const mockAddSubscription = jest.fn()
     const connectionFactory = new ThirdTimeLuckyConnectionFactory(mockAddSubscription)
     const client = new StreamSeaClient({
-      appId: 'mockId',
-      appSecret: 'mockSecret',
+      credentialOptions: {
+        type: 'secret',
+        appId: 'mockId',
+        secret: 'mockSecret',
+      },
       remoteServerHost: 'mockHost',
       remoteServerPort: '101',
       secure: false,

--- a/src/tests/stream-sea-connection.test.ts
+++ b/src/tests/stream-sea-connection.test.ts
@@ -131,8 +131,11 @@ describe('StreamSeaConnection', () => {
     const socketFactory = new BasicSocketFactory()
     const connection = new StreamSeaConnection({
       url: 'test_url',
-      clientId: 'test_client_id',
-      clientSecret: 'test_client_secret',
+      credentialOptions: {
+        type: 'basic',
+        clientId: 'test_client_id',
+        clientSecret: 'test_client_secret',
+      },
       socketFactory,
       groupId: '00000000-0000-0000-000000001234',
     })

--- a/src/tests/stream-sea-connection.test.ts
+++ b/src/tests/stream-sea-connection.test.ts
@@ -97,8 +97,11 @@ describe('StreamSeaConnection', () => {
     const socketFactory = new BasicSocketFactory()
     const connection = new StreamSeaConnection({
       url: 'test_url',
-      appId: 'test_app_id',
-      appSecret: 'test_app_secret',
+      credentialOptions: {
+        type: 'secret',
+        appId: 'test_app_id',
+        secret: 'test_app_secret',
+      },
       socketFactory,
       fanout: false,
     })
@@ -123,8 +126,11 @@ describe('StreamSeaConnection', () => {
     const socketFactory = new BasicSocketFactory()
     const connection = new StreamSeaConnection({
       url: 'test_url',
-      appId: 'test_app_id',
-      appSecret: 'wrong_secret',
+      credentialOptions: {
+        type: 'secret',
+        appId: 'test_app_id',
+        secret: 'wrong_secret',
+      },
       socketFactory,
       fanout: false,
     })

--- a/src/tests/stream-sea-connection.test.ts
+++ b/src/tests/stream-sea-connection.test.ts
@@ -8,11 +8,14 @@ class BasicSocket extends EventEmitter implements IStreamSeaSocket {
   // public sendMock = jest.fn<any, any>(() => {return;})
   public subscriptionKey?: number
   public groupId?: string
+  public verifyAuthenticationPayload = (payload: any) => {
+    expect(payload.type).toBe('basic')
+    return payload.clientSecret === 'test_client_secret'
+  }
   public sendCallbacks: Array<(m: any) => void> = [
     m => {
       expect(m.action).toBe('authenticate')
-      expect(m.payload.type).toBe('basic')
-      if (m.payload.clientSecret === 'test_client_secret') {
+      if (this.verifyAuthenticationPayload(m.payload)) {
         this.emit(
           'message',
           {
@@ -95,8 +98,24 @@ class BasicSocketFactory implements IStreamSeaSocketFactory {
   }
 }
 
+class JwtSocket extends BasicSocket {
+  public verifyAuthenticationPayload = (payload: any) => {
+    expect(payload.type).toBe('jwt')
+    return payload.jwt === 'test.client.jwt'
+  }
+}
+
+class JwtSocketFactory implements IStreamSeaSocketFactory {
+  public sockets: JwtSocket[] = []
+  createSocket = () => {
+    const socket = new JwtSocket()
+    this.sockets.push(socket)
+    return socket
+  }
+}
+
 describe('StreamSeaConnection', () => {
-  it('positive: default groupId', done => {
+  it('positive: Basic auth with default groupId', done => {
     const socketFactory = new BasicSocketFactory()
     const connection = new StreamSeaConnection({
       url: 'test_url',
@@ -127,7 +146,7 @@ describe('StreamSeaConnection', () => {
       socketFactory.sockets[0].emitSubscriptionMessage()
     }, 1000)
   })
-  it('positive: custom groupId', done => {
+  it('positive: Basic auth with custom groupId', done => {
     const socketFactory = new BasicSocketFactory()
     const connection = new StreamSeaConnection({
       url: 'test_url',
@@ -158,7 +177,7 @@ describe('StreamSeaConnection', () => {
       socketFactory.sockets[0].emitSubscriptionMessage()
     }, 1000)
   })
-  it('negative: bad credentials', done => {
+  it('negative: Basic auth with bad credentials', done => {
     const socketFactory = new BasicSocketFactory()
     const connection = new StreamSeaConnection({
       url: 'test_url',
@@ -185,6 +204,37 @@ describe('StreamSeaConnection', () => {
       // Verify that the error handler was called
       expect(errorHandler.mock.calls.length).toBe(1)
       done()
+    }, 1000)
+  })
+  it('positive: JWT auth', done => {
+    const socketFactory = new JwtSocketFactory()
+    const connection = new StreamSeaConnection({
+      url: 'test_url',
+      credentialOptions: {
+        type: 'jwt',
+        clientId: 'test_client_id',
+        jwt: 'test.client.jwt',
+      },
+      socketFactory,
+      groupId: undefined,
+    })
+    const subscription = new StreamSeaSubscription('testStream')
+    connection.addSubscription(subscription)
+    setTimeout(() => {
+      // Verify a socket was created
+      expect(socketFactory.sockets.length).toBe(1)
+      // Verify the groupId is undefined
+      expect(socketFactory.sockets[0].groupId).toBe(undefined)
+      // Verify that all send callbacks have been called
+      expect(socketFactory.sockets[0].sendCallbacks.length).toBe(0)
+      // Verify that the connection is open
+      expect(connection.status).toBe(StreamSeaConnectionStatus.open)
+      // Verify that messages on the socket are forwarded to the subscription
+      subscription.on('message', m => {
+        expect(m.foo).toBe('bar')
+        done()
+      })
+      socketFactory.sockets[0].emitSubscriptionMessage()
     }, 1000)
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
 export interface Remote {
   appId: string
-  appSecret: string
   remoteServerHost: string
   remoteServerPort: string
   secure: boolean
@@ -47,3 +46,7 @@ export interface SchemaDefinition extends Schema {
   name: string
   version: number
 }
+
+export type SecretCredentialOptions = {type: 'secret', appId: string, secret: string}
+export type JwtCredentialOptions = {type: 'jwt', appId: string, jwt: string}
+export type CredentialOptions = SecretCredentialOptions | JwtCredentialOptions


### PR DESCRIPTION
## Description
This PR adds an alternative authentication method. In addition to basic authentication with (clientId, clientSecret) we now support JWT authentication with (clientId, jwt).

The StreamSeaClient has a new method named `setCredentialOptions`. This allows an application to refresh the JWT for an existing StreamSeaClient instance. The new JWT will be applied with the next reconnection.

For now, the JWT only has one ACL field named `mustFanout`. When true, the client must subscribe using fanout mode.

The corresponding server PR is https://github.com/Portchain/stream-sea/pull/15

## How Has This Been Tested?
### JWT authentication
<!--- Describe how you tested your changes. -->
- Choose an arbitrary string as the JWT secret `K`
- Choose a stream-sea client `C`
- Using SQL, set `C`'s JWT secret to `K`:
```
UPDATE clients SET jwt_secret=... WHERE given_id=...
```
- Generate a signed JWT `J` using https://github.com/Portchain/stream-sea-jwt  with secret `K` and the default payload.
- Spin up the Hello application https://github.com/Portchain/hello-stream-sea/pull/2 with environment variable REACT_APP_JWT equal to `J`
- Use stream-sea-cli to publish a message
- Verify the message appears in the Hello application
### Server disconnect
- Repeat above, but set the JWT expiry date to 3 minutes in the future
- Verify that after 3 minutes, the Hello app is disconnected and cannot reconnect