### PR TITLE
Client-generated groupId

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+An isomorphic client library for stream-sea
+
 ### Compatibility
-This library is compatible with stream-sea ^1.1.0 (i.e. 1.1.0 <= stream-sea < 2.0)
+This library is compatible with stream-sea ^2.0 (i.e. 2.0 <= stream-sea < 3.0)
 
 ### For users
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -19,7 +19,7 @@ exports.publish = async (args) => {
         url: `${utils_1.getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/streams/${args.stream}/publish`,
         headers: {
             'content-type': 'application/json',
-            authorization: 'Basic ' + Buffer.from(`${args.appId}:${args.appSecret}`).toString('base64'),
+            authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
         },
         method: 'POST',
         gzip: true,
@@ -32,7 +32,7 @@ exports.defineStream = async (args) => {
         url: `${utils_1.getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/streams/${args.stream}/define`,
         headers: {
             'content-type': 'application/json',
-            authorization: 'Basic ' + Buffer.from(`${args.appId}:${args.appSecret}`).toString('base64'),
+            authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
         },
         method: 'POST',
         gzip: true,
@@ -45,7 +45,7 @@ exports.describeStream = async (args) => {
         url: `${utils_1.getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/streams/${args.stream}/schema`,
         headers: {
             'content-type': 'application/json',
-            authorization: 'Basic ' + Buffer.from(`${args.appId}:${args.appSecret}`).toString('base64'),
+            authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
         },
         method: 'GET',
         gzip: true,
@@ -58,7 +58,7 @@ exports.createClient = async (args) => {
         url: `${utils_1.getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client`,
         headers: {
             'content-type': 'application/json',
-            authorization: 'Basic ' + Buffer.from(`${args.appId}:${args.appSecret}`).toString('base64'),
+            authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
         },
         method: 'POST',
         gzip: true,
@@ -71,7 +71,7 @@ exports.deleteClient = async (args) => {
         url: `${utils_1.getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client/${args.clientId}`,
         headers: {
             'content-type': 'application/json',
-            authorization: 'Basic ' + Buffer.from(`${args.appId}:${args.appSecret}`).toString('base64'),
+            authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
         },
         method: 'DELETE',
         gzip: true,
@@ -83,7 +83,7 @@ exports.rotateClientSecret = async (args) => {
         url: `${utils_1.getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client/${args.clientId}`,
         headers: {
             'content-type': 'application/json',
-            authorization: 'Basic ' + Buffer.from(`${args.appId}:${args.appSecret}`).toString('base64'),
+            authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
         },
         method: 'PUT',
         gzip: true,

--- a/dist/stream-sea-client.d.ts
+++ b/dist/stream-sea-client.d.ts
@@ -26,6 +26,7 @@ export declare class StreamSeaClient extends EventEmitter {
     private RECONNECT_INTERVAL_MS;
     private CONNECTION_FAILURE_ALERT_THRESHOLD;
     private consecutiveConnectionFailures;
+    private groupId;
     constructor(options: StreamSeaClientOptions & {
         connectionFactory: IStreamSeaConnectionFactory;
     });

--- a/dist/stream-sea-client.d.ts
+++ b/dist/stream-sea-client.d.ts
@@ -6,8 +6,8 @@ interface StreamSeaClientOptions {
     remoteServerHost: string;
     remoteServerPort: string;
     secure: boolean;
-    appId: string;
-    appSecret: string;
+    clientId: string;
+    clientSecret: string;
     fanout?: boolean;
 }
 /**

--- a/dist/stream-sea-client.js
+++ b/dist/stream-sea-client.js
@@ -6,11 +6,15 @@ var __importStar = (this && this.__importStar) || function (mod) {
     result["default"] = mod;
     return result;
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const events_1 = require("events");
 const stream_sea_connection_1 = require("./stream-sea-connection");
 const utils_1 = require("./utils");
 const logger = __importStar(require("./logger"));
+const uuid_random_1 = __importDefault(require("uuid-random"));
 /**
  * A StreamSeaClient manages a StreamSeaConnection, restarting it if necessary
  *
@@ -59,7 +63,7 @@ class StreamSeaClient extends events_1.EventEmitter {
                 url: `${utils_1.getWsURLScheme(this.options.secure)}://${this.options.remoteServerHost}:${this.options.remoteServerPort}/api/v1/streams`,
                 appId: this.options.appId,
                 appSecret: this.options.appSecret,
-                fanout: !!this.options.fanout,
+                groupId: this.groupId,
             });
             this.attachConnectionEventHandlers();
             this.subscriptions.forEach(subscription => this.connection.addSubscription(subscription));
@@ -69,11 +73,12 @@ class StreamSeaClient extends events_1.EventEmitter {
             this.connection.addSubscription(subscription);
         };
         this.options = options;
+        this.groupId = options.fanout ? uuid_random_1.default() : undefined;
         this.connection = options.connectionFactory.createConnection({
             url: `${utils_1.getWsURLScheme(options.secure)}://${options.remoteServerHost}:${options.remoteServerPort}/api/v1/streams`,
             appId: options.appId,
             appSecret: options.appSecret,
-            fanout: !!options.fanout,
+            groupId: this.groupId,
         });
         this.attachConnectionEventHandlers();
     }

--- a/dist/stream-sea-client.js
+++ b/dist/stream-sea-client.js
@@ -61,8 +61,8 @@ class StreamSeaClient extends events_1.EventEmitter {
             logger.warn('StreamSeaClient: Reopening connection');
             this.connection = this.options.connectionFactory.createConnection({
                 url: `${utils_1.getWsURLScheme(this.options.secure)}://${this.options.remoteServerHost}:${this.options.remoteServerPort}/api/v1/streams`,
-                appId: this.options.appId,
-                appSecret: this.options.appSecret,
+                clientId: this.options.clientId,
+                clientSecret: this.options.clientSecret,
                 groupId: this.groupId,
             });
             this.attachConnectionEventHandlers();
@@ -76,8 +76,8 @@ class StreamSeaClient extends events_1.EventEmitter {
         this.groupId = options.fanout ? uuid_random_1.default() : undefined;
         this.connection = options.connectionFactory.createConnection({
             url: `${utils_1.getWsURLScheme(options.secure)}://${options.remoteServerHost}:${options.remoteServerPort}/api/v1/streams`,
-            appId: options.appId,
-            appSecret: options.appSecret,
+            clientId: options.clientId,
+            clientSecret: options.clientSecret,
             groupId: this.groupId,
         });
         this.attachConnectionEventHandlers();

--- a/dist/stream-sea-connection.d.ts
+++ b/dist/stream-sea-connection.d.ts
@@ -9,7 +9,7 @@ export interface StreamSeaConnectionOptions {
     url: string;
     appId: string;
     appSecret: string;
-    fanout: boolean;
+    groupId: string | undefined;
 }
 export declare enum StreamSeaConnectionStatus {
     init = "init",

--- a/dist/stream-sea-connection.d.ts
+++ b/dist/stream-sea-connection.d.ts
@@ -7,8 +7,8 @@ export interface IStreamSeaConnection extends EventEmitter {
 }
 export interface StreamSeaConnectionOptions {
     url: string;
-    appId: string;
-    appSecret: string;
+    clientId: string;
+    clientSecret: string;
     groupId: string | undefined;
 }
 export declare enum StreamSeaConnectionStatus {

--- a/dist/stream-sea-connection.js
+++ b/dist/stream-sea-connection.js
@@ -139,7 +139,7 @@ class StreamSeaConnection extends events_1.EventEmitter {
     checkSubscriptionsQueue() {
         if (this.status === StreamSeaConnectionStatus.open) {
             this.subscriptionsQueue.forEach(subscription => {
-                this.sendAndExpectMultiReply('subscribe', subscription.streamName, this.options.fanout, {
+                this.sendAndExpectMultiReply('subscribe', subscription.streamName, this.options.groupId, {
                     resolve: (m) => {
                         return;
                     },
@@ -175,13 +175,13 @@ class StreamSeaConnection extends events_1.EventEmitter {
     /**
      * Send a message expecting multiple replies
      */
-    sendAndExpectMultiReply(action, payload, fanout, firstReplyCallback, otherRepliesCallback) {
+    sendAndExpectMultiReply(action, payload, groupId, firstReplyCallback, otherRepliesCallback) {
         const msgId = this.generateNextMessageId();
         this.socket.send(JSON.stringify({
             id: msgId,
             action,
             payload,
-            fanout,
+            groupId,
         }));
         this.callbacksMap.set(msgId, {
             type: 'MultiReply',

--- a/dist/stream-sea-connection.js
+++ b/dist/stream-sea-connection.js
@@ -32,6 +32,7 @@ class StreamSeaConnection extends events_1.EventEmitter {
         this.callbacksMap = new Map();
         this.onSocketOpen = () => {
             this.sendAndExpectSingleReply('authenticate', {
+                type: 'basic',
                 clientId: this.options.clientId,
                 clientSecret: this.options.clientSecret,
             })

--- a/dist/stream-sea-connection.js
+++ b/dist/stream-sea-connection.js
@@ -32,8 +32,8 @@ class StreamSeaConnection extends events_1.EventEmitter {
         this.callbacksMap = new Map();
         this.onSocketOpen = () => {
             this.sendAndExpectSingleReply('authenticate', {
-                username: this.options.appId,
-                password: this.options.appSecret,
+                username: this.options.clientId,
+                password: this.options.clientSecret,
             })
                 .then(() => {
                 this.emit('open');

--- a/dist/stream-sea-connection.js
+++ b/dist/stream-sea-connection.js
@@ -32,8 +32,8 @@ class StreamSeaConnection extends events_1.EventEmitter {
         this.callbacksMap = new Map();
         this.onSocketOpen = () => {
             this.sendAndExpectSingleReply('authenticate', {
-                username: this.options.clientId,
-                password: this.options.clientSecret,
+                clientId: this.options.clientId,
+                clientSecret: this.options.clientSecret,
             })
                 .then(() => {
                 this.emit('open');

--- a/dist/tests/stream-sea-client.test.js
+++ b/dist/tests/stream-sea-client.test.js
@@ -63,8 +63,8 @@ describe('StreamSeaClient', () => {
         const mockAddSubscription = jest.fn();
         const connectionFactory = new GoodConnectionFactory(mockAddSubscription);
         const client = new stream_sea_client_1.StreamSeaClient({
-            appId: 'mockId',
-            appSecret: 'mockSecret',
+            clientId: 'mockId',
+            clientSecret: 'mockSecret',
             remoteServerHost: 'mockHost',
             remoteServerPort: '101',
             secure: false,
@@ -85,8 +85,8 @@ describe('StreamSeaClient', () => {
         const mockAddSubscription = jest.fn();
         const connectionFactory = new ThirdTimeLuckyConnectionFactory(mockAddSubscription);
         const client = new stream_sea_client_1.StreamSeaClient({
-            appId: 'mockId',
-            appSecret: 'mockSecret',
+            clientId: 'mockId',
+            clientSecret: 'mockSecret',
             remoteServerHost: 'mockHost',
             remoteServerPort: '101',
             secure: false,

--- a/dist/tests/stream-sea-connection.test.js
+++ b/dist/tests/stream-sea-connection.test.js
@@ -46,6 +46,7 @@ class BasicSocket extends events_1.EventEmitter {
             m => {
                 expect(m.action).toBe('subscribe');
                 this.subscriptionKey = m.id;
+                this.groupId = m.groupId;
                 this.emit('message', {
                     data: JSON.stringify({
                         id: m.id,
@@ -88,7 +89,7 @@ class BasicSocketFactory {
     }
 }
 describe('StreamSeaConnection', () => {
-    it('basic flow', done => {
+    it('positive: default groupId', done => {
         const socketFactory = new BasicSocketFactory();
         const connection = new stream_sea_connection_1.StreamSeaConnection({
             url: 'test_url',
@@ -102,6 +103,8 @@ describe('StreamSeaConnection', () => {
         setTimeout(() => {
             // Verify a socket was created
             expect(socketFactory.sockets.length).toBe(1);
+            // Verify the groupId is undefined
+            expect(socketFactory.sockets[0].groupId).toBe(undefined);
             // Verify that all send callbacks have been called
             expect(socketFactory.sockets[0].sendCallbacks.length).toBe(0);
             // Verify that the connection is open
@@ -114,7 +117,35 @@ describe('StreamSeaConnection', () => {
             socketFactory.sockets[0].emitSubscriptionMessage();
         }, 1000);
     });
-    it('bad credentials', done => {
+    it('positive: custom groupId', done => {
+        const socketFactory = new BasicSocketFactory();
+        const connection = new stream_sea_connection_1.StreamSeaConnection({
+            url: 'test_url',
+            clientId: 'test_client_id',
+            clientSecret: 'test_client_secret',
+            socketFactory,
+            groupId: '00000000-0000-0000-000000001234',
+        });
+        const subscription = new stream_sea_subscription_1.StreamSeaSubscription('testStream');
+        connection.addSubscription(subscription);
+        setTimeout(() => {
+            // Verify a socket was created
+            expect(socketFactory.sockets.length).toBe(1);
+            // Verify the groupId is undefined
+            expect(socketFactory.sockets[0].groupId).toBe('00000000-0000-0000-000000001234');
+            // Verify that all send callbacks have been called
+            expect(socketFactory.sockets[0].sendCallbacks.length).toBe(0);
+            // Verify that the connection is open
+            expect(connection.status).toBe(stream_sea_connection_1.StreamSeaConnectionStatus.open);
+            // Verify that messages on the socket are forwarded to the subscription
+            subscription.on('message', m => {
+                expect(m.foo).toBe('bar');
+                done();
+            });
+            socketFactory.sockets[0].emitSubscriptionMessage();
+        }, 1000);
+    });
+    it('negative: bad credentials', done => {
         const socketFactory = new BasicSocketFactory();
         const connection = new stream_sea_connection_1.StreamSeaConnection({
             url: 'test_url',

--- a/dist/tests/stream-sea-connection.test.js
+++ b/dist/tests/stream-sea-connection.test.js
@@ -94,7 +94,7 @@ describe('StreamSeaConnection', () => {
             appId: 'test_app_id',
             appSecret: 'test_app_secret',
             socketFactory,
-            fanout: false,
+            groupId: undefined,
         });
         const subscription = new stream_sea_subscription_1.StreamSeaSubscription('testStream');
         connection.addSubscription(subscription);
@@ -120,7 +120,7 @@ describe('StreamSeaConnection', () => {
             appId: 'test_app_id',
             appSecret: 'wrong_secret',
             socketFactory,
-            fanout: false,
+            groupId: undefined,
         });
         const subscription = new stream_sea_subscription_1.StreamSeaSubscription('testStream');
         connection.addSubscription(subscription);

--- a/dist/tests/stream-sea-connection.test.js
+++ b/dist/tests/stream-sea-connection.test.js
@@ -17,6 +17,7 @@ class BasicSocket extends events_1.EventEmitter {
         this.sendCallbacks = [
             m => {
                 expect(m.action).toBe('authenticate');
+                expect(m.payload.type).toBe('basic');
                 if (m.payload.clientSecret === 'test_client_secret') {
                     this.emit('message', {
                         data: JSON.stringify({

--- a/dist/tests/stream-sea-connection.test.js
+++ b/dist/tests/stream-sea-connection.test.js
@@ -17,7 +17,7 @@ class BasicSocket extends events_1.EventEmitter {
         this.sendCallbacks = [
             m => {
                 expect(m.action).toBe('authenticate');
-                if (m.payload.password === 'test_client_secret') {
+                if (m.payload.clientSecret === 'test_client_secret') {
                     this.emit('message', {
                         data: JSON.stringify({
                             id: m.id,

--- a/dist/tests/stream-sea-connection.test.js
+++ b/dist/tests/stream-sea-connection.test.js
@@ -17,7 +17,7 @@ class BasicSocket extends events_1.EventEmitter {
         this.sendCallbacks = [
             m => {
                 expect(m.action).toBe('authenticate');
-                if (m.payload.password === 'test_app_secret') {
+                if (m.payload.password === 'test_client_secret') {
                     this.emit('message', {
                         data: JSON.stringify({
                             id: m.id,
@@ -91,8 +91,8 @@ describe('StreamSeaConnection', () => {
         const socketFactory = new BasicSocketFactory();
         const connection = new stream_sea_connection_1.StreamSeaConnection({
             url: 'test_url',
-            appId: 'test_app_id',
-            appSecret: 'test_app_secret',
+            clientId: 'test_client_id',
+            clientSecret: 'test_client_secret',
             socketFactory,
             groupId: undefined,
         });
@@ -117,8 +117,8 @@ describe('StreamSeaConnection', () => {
         const socketFactory = new BasicSocketFactory();
         const connection = new stream_sea_connection_1.StreamSeaConnection({
             url: 'test_url',
-            appId: 'test_app_id',
-            appSecret: 'wrong_secret',
+            clientId: 'test_client_id',
+            clientSecret: 'wrong_secret',
             socketFactory,
             groupId: undefined,
         });

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -1,6 +1,6 @@
 export interface Remote {
-    appId: string;
-    appSecret: string;
+    clientId: string;
+    clientSecret: string;
     remoteServerHost: string;
     remoteServerPort: string;
     secure: boolean;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "isomorphic-ws": "^4.0.1",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.8",
-    "uuid-random": "1.3.0",
+    "uuid-random": "^1.3.0",
     "ws": "^7.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-sea-client",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -23,6 +23,7 @@
     "isomorphic-ws": "^4.0.1",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.8",
+    "uuid-random": "1.3.0",
     "ws": "^7.2.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export const publish = async (args: Remote & Stream & { payload: any }) => {
     url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/streams/${args.stream}/publish`,
     headers: {
       'content-type': 'application/json',
-      authorization: 'Basic ' + Buffer.from(`${args.appId}:${args.appSecret}`).toString('base64'),
+      authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
     },
     method: 'POST',
     gzip: true,
@@ -31,7 +31,7 @@ export const defineStream = async (args: Remote & Stream & SchemaDefinition) => 
     url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/streams/${args.stream}/define`,
     headers: {
       'content-type': 'application/json',
-      authorization: 'Basic ' + Buffer.from(`${args.appId}:${args.appSecret}`).toString('base64'),
+      authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
     },
     method: 'POST',
     gzip: true,
@@ -45,7 +45,7 @@ export const describeStream = async (args: Remote & Stream & SchemaDefinition) =
     url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/streams/${args.stream}/schema`,
     headers: {
       'content-type': 'application/json',
-      authorization: 'Basic ' + Buffer.from(`${args.appId}:${args.appSecret}`).toString('base64'),
+      authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
     },
     method: 'GET',
     gzip: true,
@@ -59,7 +59,7 @@ export const createClient = async (args: Remote & { description: string }) => {
     url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client`,
     headers: {
       'content-type': 'application/json',
-      authorization: 'Basic ' + Buffer.from(`${args.appId}:${args.appSecret}`).toString('base64'),
+      authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
     },
     method: 'POST',
     gzip: true,
@@ -73,7 +73,7 @@ export const deleteClient = async (args: Remote & { clientId: string }) => {
     url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client/${args.clientId}`,
     headers: {
       'content-type': 'application/json',
-      authorization: 'Basic ' + Buffer.from(`${args.appId}:${args.appSecret}`).toString('base64'),
+      authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
     },
     method: 'DELETE',
     gzip: true,
@@ -86,7 +86,7 @@ export const rotateClientSecret = async (args: Remote & { clientId: string }) =>
     url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client/${args.clientId}`,
     headers: {
       'content-type': 'application/json',
-      authorization: 'Basic ' + Buffer.from(`${args.appId}:${args.appSecret}`).toString('base64'),
+      authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
     },
     method: 'PUT',
     gzip: true,

--- a/src/stream-sea-client.ts
+++ b/src/stream-sea-client.ts
@@ -3,6 +3,7 @@ import { IStreamSeaConnectionFactory, IStreamSeaConnection, StreamSeaConnectionF
 import { IStreamSeaSubscription } from './stream-sea-subscription'
 import { getWsURLScheme } from './utils'
 import * as logger from './logger'
+import uuid from 'uuid-random'
 
 interface StreamSeaClientOptions {
   remoteServerHost: string
@@ -29,15 +30,17 @@ export class StreamSeaClient extends EventEmitter {
   private RECONNECT_INTERVAL_MS = 3000
   private CONNECTION_FAILURE_ALERT_THRESHOLD = 20 // Log an error after this many consecutive failures
   private consecutiveConnectionFailures = 0
+  private groupId: string | undefined
 
   constructor(options: StreamSeaClientOptions & { connectionFactory: IStreamSeaConnectionFactory }) {
     super()
     this.options = options
+    this.groupId = options.fanout ? uuid() : undefined
     this.connection = options.connectionFactory.createConnection({
       url: `${getWsURLScheme(options.secure)}://${options.remoteServerHost}:${options.remoteServerPort}/api/v1/streams`,
       appId: options.appId,
       appSecret: options.appSecret,
-      fanout: !!options.fanout,
+      groupId: this.groupId,
     })
     this.attachConnectionEventHandlers()
   }
@@ -77,7 +80,7 @@ export class StreamSeaClient extends EventEmitter {
       url: `${getWsURLScheme(this.options.secure)}://${this.options.remoteServerHost}:${this.options.remoteServerPort}/api/v1/streams`,
       appId: this.options.appId,
       appSecret: this.options.appSecret,
-      fanout: !!this.options.fanout,
+      groupId: this.groupId,
     })
     this.attachConnectionEventHandlers()
     this.subscriptions.forEach(subscription => this.connection.addSubscription(subscription))

--- a/src/stream-sea-client.ts
+++ b/src/stream-sea-client.ts
@@ -9,8 +9,8 @@ interface StreamSeaClientOptions {
   remoteServerHost: string
   remoteServerPort: string
   secure: boolean
-  appId: string
-  appSecret: string
+  clientId: string
+  clientSecret: string
   fanout?: boolean
 }
 
@@ -38,8 +38,8 @@ export class StreamSeaClient extends EventEmitter {
     this.groupId = options.fanout ? uuid() : undefined
     this.connection = options.connectionFactory.createConnection({
       url: `${getWsURLScheme(options.secure)}://${options.remoteServerHost}:${options.remoteServerPort}/api/v1/streams`,
-      appId: options.appId,
-      appSecret: options.appSecret,
+      clientId: options.clientId,
+      clientSecret: options.clientSecret,
       groupId: this.groupId,
     })
     this.attachConnectionEventHandlers()
@@ -78,8 +78,8 @@ export class StreamSeaClient extends EventEmitter {
     logger.warn('StreamSeaClient: Reopening connection')
     this.connection = this.options.connectionFactory.createConnection({
       url: `${getWsURLScheme(this.options.secure)}://${this.options.remoteServerHost}:${this.options.remoteServerPort}/api/v1/streams`,
-      appId: this.options.appId,
-      appSecret: this.options.appSecret,
+      clientId: this.options.clientId,
+      clientSecret: this.options.clientSecret,
       groupId: this.groupId,
     })
     this.attachConnectionEventHandlers()

--- a/src/stream-sea-connection.ts
+++ b/src/stream-sea-connection.ts
@@ -90,6 +90,7 @@ export class StreamSeaConnection extends EventEmitter implements IStreamSeaConne
 
   private onSocketOpen = () => {
     this.sendAndExpectSingleReply('authenticate', {
+      type: 'basic',
       clientId: this.options.clientId,
       clientSecret: this.options.clientSecret,
     })

--- a/src/stream-sea-connection.ts
+++ b/src/stream-sea-connection.ts
@@ -13,8 +13,8 @@ export interface IStreamSeaConnection extends EventEmitter {
 
 export interface StreamSeaConnectionOptions {
   url: string
-  appId: string
-  appSecret: string
+  clientId: string
+  clientSecret: string
   groupId: string | undefined
 }
 
@@ -90,8 +90,8 @@ export class StreamSeaConnection extends EventEmitter implements IStreamSeaConne
 
   private onSocketOpen = () => {
     this.sendAndExpectSingleReply('authenticate', {
-      username: this.options.appId,
-      password: this.options.appSecret,
+      username: this.options.clientId,
+      password: this.options.clientSecret,
     })
       .then(() => {
         this.emit('open')

--- a/src/stream-sea-connection.ts
+++ b/src/stream-sea-connection.ts
@@ -90,8 +90,8 @@ export class StreamSeaConnection extends EventEmitter implements IStreamSeaConne
 
   private onSocketOpen = () => {
     this.sendAndExpectSingleReply('authenticate', {
-      username: this.options.clientId,
-      password: this.options.clientSecret,
+      clientId: this.options.clientId,
+      clientSecret: this.options.clientSecret,
     })
       .then(() => {
         this.emit('open')

--- a/src/stream-sea-connection.ts
+++ b/src/stream-sea-connection.ts
@@ -15,7 +15,7 @@ export interface StreamSeaConnectionOptions {
   url: string
   appId: string
   appSecret: string
-  fanout: boolean
+  groupId: string | undefined
 }
 
 export enum StreamSeaConnectionStatus {
@@ -197,7 +197,7 @@ export class StreamSeaConnection extends EventEmitter implements IStreamSeaConne
         this.sendAndExpectMultiReply(
           'subscribe',
           subscription.streamName,
-          this.options.fanout,
+          this.options.groupId,
           {
             resolve: (m: any) => {
               return
@@ -240,14 +240,14 @@ export class StreamSeaConnection extends EventEmitter implements IStreamSeaConne
   /**
    * Send a message expecting multiple replies
    */
-  private sendAndExpectMultiReply(action: string, payload: any, fanout: boolean, firstReplyCallback: PromiseProxy, otherRepliesCallback: PromiseProxy) {
+  private sendAndExpectMultiReply(action: string, payload: any, groupId: string | undefined, firstReplyCallback: PromiseProxy, otherRepliesCallback: PromiseProxy) {
     const msgId = this.generateNextMessageId()
     this.socket.send(
       JSON.stringify({
         id: msgId,
         action,
         payload,
-        fanout,
+        groupId,
       })
     )
     this.callbacksMap.set(msgId, {

--- a/src/tests/stream-sea-client.test.ts
+++ b/src/tests/stream-sea-client.test.ts
@@ -68,8 +68,8 @@ describe('StreamSeaClient', () => {
     const mockAddSubscription = jest.fn()
     const connectionFactory = new GoodConnectionFactory(mockAddSubscription)
     const client = new StreamSeaClient({
-      appId: 'mockId',
-      appSecret: 'mockSecret',
+      clientId: 'mockId',
+      clientSecret: 'mockSecret',
       remoteServerHost: 'mockHost',
       remoteServerPort: '101',
       secure: false,
@@ -91,8 +91,8 @@ describe('StreamSeaClient', () => {
     const mockAddSubscription = jest.fn()
     const connectionFactory = new ThirdTimeLuckyConnectionFactory(mockAddSubscription)
     const client = new StreamSeaClient({
-      appId: 'mockId',
-      appSecret: 'mockSecret',
+      clientId: 'mockId',
+      clientSecret: 'mockSecret',
       remoteServerHost: 'mockHost',
       remoteServerPort: '101',
       secure: false,

--- a/src/tests/stream-sea-connection.test.ts
+++ b/src/tests/stream-sea-connection.test.ts
@@ -10,6 +10,7 @@ class BasicSocket extends EventEmitter implements IStreamSeaSocket {
   public sendCallbacks: Array<(m: any) => void> = [
     m => {
       expect(m.action).toBe('authenticate')
+      expect(m.payload.type).toBe('basic')
       if (m.payload.clientSecret === 'test_client_secret') {
         this.emit(
           'message',

--- a/src/tests/stream-sea-connection.test.ts
+++ b/src/tests/stream-sea-connection.test.ts
@@ -100,7 +100,7 @@ describe('StreamSeaConnection', () => {
       appId: 'test_app_id',
       appSecret: 'test_app_secret',
       socketFactory,
-      fanout: false,
+      groupId: undefined,
     })
     const subscription = new StreamSeaSubscription('testStream')
     connection.addSubscription(subscription)
@@ -126,7 +126,7 @@ describe('StreamSeaConnection', () => {
       appId: 'test_app_id',
       appSecret: 'wrong_secret',
       socketFactory,
-      fanout: false,
+      groupId: undefined,
     })
     const subscription = new StreamSeaSubscription('testStream')
     connection.addSubscription(subscription)

--- a/src/tests/stream-sea-connection.test.ts
+++ b/src/tests/stream-sea-connection.test.ts
@@ -10,7 +10,7 @@ class BasicSocket extends EventEmitter implements IStreamSeaSocket {
   public sendCallbacks: Array<(m: any) => void> = [
     m => {
       expect(m.action).toBe('authenticate')
-      if (m.payload.password === 'test_client_secret') {
+      if (m.payload.clientSecret === 'test_client_secret') {
         this.emit(
           'message',
           {

--- a/src/tests/stream-sea-connection.test.ts
+++ b/src/tests/stream-sea-connection.test.ts
@@ -7,6 +7,7 @@ import { StreamSeaSubscription } from '../stream-sea-subscription'
 class BasicSocket extends EventEmitter implements IStreamSeaSocket {
   // public sendMock = jest.fn<any, any>(() => {return;})
   public subscriptionKey?: number
+  public groupId?: string
   public sendCallbacks: Array<(m: any) => void> = [
     m => {
       expect(m.action).toBe('authenticate')
@@ -44,6 +45,7 @@ class BasicSocket extends EventEmitter implements IStreamSeaSocket {
     m => {
       expect(m.action).toBe('subscribe')
       this.subscriptionKey = m.id
+      this.groupId = m.groupId
       this.emit(
         'message',
         {
@@ -94,7 +96,7 @@ class BasicSocketFactory implements IStreamSeaSocketFactory {
 }
 
 describe('StreamSeaConnection', () => {
-  it('basic flow', done => {
+  it('positive: default groupId', done => {
     const socketFactory = new BasicSocketFactory()
     const connection = new StreamSeaConnection({
       url: 'test_url',
@@ -108,6 +110,8 @@ describe('StreamSeaConnection', () => {
     setTimeout(() => {
       // Verify a socket was created
       expect(socketFactory.sockets.length).toBe(1)
+      // Verify the groupId is undefined
+      expect(socketFactory.sockets[0].groupId).toBe(undefined)
       // Verify that all send callbacks have been called
       expect(socketFactory.sockets[0].sendCallbacks.length).toBe(0)
       // Verify that the connection is open
@@ -120,7 +124,35 @@ describe('StreamSeaConnection', () => {
       socketFactory.sockets[0].emitSubscriptionMessage()
     }, 1000)
   })
-  it('bad credentials', done => {
+  it('positive: custom groupId', done => {
+    const socketFactory = new BasicSocketFactory()
+    const connection = new StreamSeaConnection({
+      url: 'test_url',
+      clientId: 'test_client_id',
+      clientSecret: 'test_client_secret',
+      socketFactory,
+      groupId: '00000000-0000-0000-000000001234',
+    })
+    const subscription = new StreamSeaSubscription('testStream')
+    connection.addSubscription(subscription)
+    setTimeout(() => {
+      // Verify a socket was created
+      expect(socketFactory.sockets.length).toBe(1)
+      // Verify the groupId is undefined
+      expect(socketFactory.sockets[0].groupId).toBe('00000000-0000-0000-000000001234')
+      // Verify that all send callbacks have been called
+      expect(socketFactory.sockets[0].sendCallbacks.length).toBe(0)
+      // Verify that the connection is open
+      expect(connection.status).toBe(StreamSeaConnectionStatus.open)
+      // Verify that messages on the socket are forwarded to the subscription
+      subscription.on('message', m => {
+        expect(m.foo).toBe('bar')
+        done()
+      })
+      socketFactory.sockets[0].emitSubscriptionMessage()
+    }, 1000)
+  })
+  it('negative: bad credentials', done => {
     const socketFactory = new BasicSocketFactory()
     const connection = new StreamSeaConnection({
       url: 'test_url',

--- a/src/tests/stream-sea-connection.test.ts
+++ b/src/tests/stream-sea-connection.test.ts
@@ -10,7 +10,7 @@ class BasicSocket extends EventEmitter implements IStreamSeaSocket {
   public sendCallbacks: Array<(m: any) => void> = [
     m => {
       expect(m.action).toBe('authenticate')
-      if (m.payload.password === 'test_app_secret') {
+      if (m.payload.password === 'test_client_secret') {
         this.emit(
           'message',
           {
@@ -97,8 +97,8 @@ describe('StreamSeaConnection', () => {
     const socketFactory = new BasicSocketFactory()
     const connection = new StreamSeaConnection({
       url: 'test_url',
-      appId: 'test_app_id',
-      appSecret: 'test_app_secret',
+      clientId: 'test_client_id',
+      clientSecret: 'test_client_secret',
       socketFactory,
       groupId: undefined,
     })
@@ -123,8 +123,8 @@ describe('StreamSeaConnection', () => {
     const socketFactory = new BasicSocketFactory()
     const connection = new StreamSeaConnection({
       url: 'test_url',
-      appId: 'test_app_id',
-      appSecret: 'wrong_secret',
+      clientId: 'test_client_id',
+      clientSecret: 'wrong_secret',
       socketFactory,
       groupId: undefined,
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export interface Remote {
-  appId: string
-  appSecret: string
+  clientId: string
+  clientSecret: string
   remoteServerHost: string
   remoteServerPort: string
   secure: boolean


### PR DESCRIPTION
This PR goes together with https://github.com/Portchain/stream-sea/pull/17 and https://github.com/Portchain/stream-sea-cli/pull/6 . It introduces non-backwards-compatible changes to the stream-sea wire protocol, bumping the client version from 2.1 to 3.0 and the server version from 1.2 to 2.0.

- The `appId` field in the wire protocol authentication message is renamed to `clientId`
- The `appSecret` field in the wire protocol authentication message is renamed to `clientSecret`
- A `type` field is added to the wire protocol authentication message, always set to "basic". This is to prepare for the upcoming JWT feature where an alternative value will be supported.
- The `fanout` field is removed. In order to connect in fanout mode, a client generates a random groupId and sends that to the server in the `groupId` field.

## Testing
- Set up the following locally:
  - Stream-sea server with https://github.com/Portchain/stream-sea/pull/17
  - Stream-sea CLI with https://github.com/Portchain/stream-sea-cli/pull/6 linked against stream-sea-client with this PR
- Spin up the stream-sea server
- Publish a message using the CLI
- Subscribe using the CLI
- Verify that messages are received