### PR TITLE
Use git with --no-pager in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             # However, some type declarations may differ between minor compiler versions due to a typescript issue: https://github.com/microsoft/TypeScript/issues/17944
             # Therefore we exclude type declarations from the 'git diff' comparison
             # When the typescript issue is resolved, we can just use 'git diff'
-            - run: if [[ $(git diff -- . ':(exclude)**/*.d.ts') ]]; then echo "Build output does not match checked-in assets"; git diff -- . ':(exclude)**/*.d.ts'; exit 1; fi;
+            - run: if [[ $(git --no-pager diff -- . ':(exclude)**/*.d.ts') ]]; then echo "Build output does not match checked-in assets"; git --no-pager diff -- . ':(exclude)**/*.d.ts'; exit 1; fi;
             - run: npm test
 workflows:
     build-and-test:


### PR DESCRIPTION
If `git diff` output is too long, git starts a pager process such as `less`, causing CI to hang.
This PR forces git to not use a pager process.