### PR TITLE
Rotatable JWT public key

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -30,3 +30,9 @@ export declare const rotateClientSecret: (args: Remote & {
     clientSecret: string;
     clientId: string;
 }) => Promise<any>;
+export declare const rotateClientJwtPublicKey: (args: Remote & {
+    clientSecret: string;
+    clientId: string;
+} & {
+    jwtPublicKey: string | null;
+}) => Promise<any>;

--- a/dist/index.js
+++ b/dist/index.js
@@ -112,3 +112,16 @@ exports.rotateClientSecret = async (args) => {
         json: true,
     });
 };
+exports.rotateClientJwtPublicKey = async (args) => {
+    return await request_promise_native_1.default({
+        url: `${utils_1.getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client/${args.clientId}`,
+        headers: {
+            'content-type': 'application/json',
+            authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
+        },
+        method: 'PUT',
+        gzip: true,
+        json: true,
+        body: { jwtPublicKey: args.jwtPublicKey },
+    });
+};

--- a/dist/index.js
+++ b/dist/index.js
@@ -114,7 +114,7 @@ exports.rotateClientSecret = async (args) => {
 };
 exports.rotateClientJwtPublicKey = async (args) => {
     return await request_promise_native_1.default({
-        url: `${utils_1.getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client/${args.clientId}`,
+        url: `${utils_1.getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client/${args.clientId}/jwt-public-key`,
         headers: {
             'content-type': 'application/json',
             authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-sea-client",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,3 +116,17 @@ export const rotateClientSecret = async (args: Remote & { clientSecret: string, 
     json: true,
   })
 }
+
+export const rotateClientJwtPublicKey = async (args: Remote & { clientSecret: string, clientId: string } & {jwtPublicKey: string | null}) => {
+  return await request({
+    url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client/${args.clientId}`,
+    headers: {
+      'content-type': 'application/json',
+      authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
+    },
+    method: 'PUT',
+    gzip: true,
+    json: true,
+    body: { jwtPublicKey: args.jwtPublicKey },
+  })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ export const rotateClientSecret = async (args: Remote & { clientSecret: string, 
 
 export const rotateClientJwtPublicKey = async (args: Remote & { clientSecret: string, clientId: string } & {jwtPublicKey: string | null}) => {
   return await request({
-    url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client/${args.clientId}`,
+    url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/client/${args.clientId}/jwt-public-key`,
     headers: {
       'content-type': 'application/json',
       authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),


### PR DESCRIPTION
Add a method to rotate JWT public key

## Related PRs
https://github.com/Portchain/stream-sea-cli/pull/7
https://github.com/Portchain/stream-sea/pull/18

## Manual testing
- Spin up stream-sea with PR 18
- Link CLI with PR 7 against this PR
- Verify you can update a client's public key:
```
npm run dev -- rotate-jwt -h localhost -p 3104 --clientId xxxxx --clientSecret xxxxxxxxxxxxxxxxxx -k "$(cat my-public-key.pem)"
```
- Verify you can clear a client's public key:
```
npm run dev -- rotate-jwt -h localhost -p 3104 --clientId xxxxx --clientSecret xxxxxxxxxxxxxxxxxx -k null
```