### PR TITLE
Versions vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 An isomorphic client library for stream-sea
 
 # Compatibility
-This library is compatible with stream-sea ^2.1 (i.e. 2.1 <= stream-sea < 3.0)
+This library is compatible with stream-sea ^2.3 (i.e. 2.3 <= stream-sea < 3.0)
 
 # For users
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -36,3 +36,9 @@ export declare const rotateClientJwtPublicKey: (args: Remote & {
 } & {
     jwtPublicKey: string | null;
 }) => Promise<any>;
+export declare const getSchemaVersionsVector: (args: Remote & {
+    clientSecret: string;
+    clientId: string;
+} & {
+    schemaNames: string[];
+}) => Promise<any>;

--- a/dist/index.js
+++ b/dist/index.js
@@ -125,3 +125,16 @@ exports.rotateClientJwtPublicKey = async (args) => {
         body: { jwtPublicKey: args.jwtPublicKey },
     });
 };
+exports.getSchemaVersionsVector = async (args) => {
+    return (await request_promise_native_1.default({
+        url: `${utils_1.getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/schema-versions-vector`,
+        headers: {
+            'content-type': 'application/json',
+            authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
+        },
+        method: 'POST',
+        gzip: true,
+        json: true,
+        body: { schemaNames: args.schemaNames },
+    })).versionsVector;
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-sea-client",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,3 +130,17 @@ export const rotateClientJwtPublicKey = async (args: Remote & { clientSecret: st
     body: { jwtPublicKey: args.jwtPublicKey },
   })
 }
+
+export const getSchemaVersionsVector = async (args: Remote & { clientSecret: string, clientId: string } & {schemaNames: string[]}) => {
+  return (await request({
+    url: `${getHttpURLScheme(args.secure)}://${args.remoteServerHost}:${args.remoteServerPort}/api/v1/schema-versions-vector`,
+    headers: {
+      'content-type': 'application/json',
+      authorization: 'Basic ' + Buffer.from(`${args.clientId}:${args.clientSecret}`).toString('base64'),
+    },
+    method: 'POST',
+    gzip: true,
+    json: true,
+    body: { schemaNames: args.schemaNames },
+  })).versionsVector
+}


### PR DESCRIPTION
Add method to fetch schema versions vector
### Related PRs
https://github.com/Portchain/stream-sea/pull/21
https://github.com/Portchain/stream-sea-cli/pull/8

### Manual testing
- Link https://github.com/Portchain/stream-sea-cli/pull/8 against this PR
- Spin up stream-sea server with https://github.com/Portchain/stream-sea/pull/21
- Run the svv command with a string of three schema names, one of which is non-existent
- Verify the versions for the existing schemas are correct in the version vector
- Verify the version for the non-existent schema is null in the version vector