### PR TITLE
Require RS512 algorithm for JWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 An isomorphic client library for stream-sea
 
 # Compatibility
-This library is compatible with stream-sea ^2.3 (i.e. 2.3 <= stream-sea < 3.0)
+This library is compatible with stream-sea ^4.0 (i.e. 4.0 <= stream-sea < 5.0)
 
 # For users
 
@@ -47,7 +47,9 @@ at least every 30 seconds to avoid idle connections being closed
 - In order to authenticate with the Basic method, the `payload` of the Authentication Request message must have the following fields:
   - A `type` field with value `"jwt"`
   - A `clientId` field of JSON type `string`
-  - A `jwt` field of JSON type `string` containing the stream-sea JWT that is signed and serialized using the client JWT secret and RFC 7515 JWS Compact Serialization
+  - A `jwt` field of JSON type `string` containing the stream-sea JWT that is:
+	  - signed using the client JWT public key with the RS512 algorithm
+		- serialized to a string using RFC 7515 JWS Compact Serialization
 - The server must respond to an Authentication Request message with exactly one Authentication Response message
 
 ### Stream-sea JWT

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ at least every 30 seconds to avoid idle connections being closed
   - A `clientId` field of JSON type `string`
   - A `jwt` field of JSON type `string` containing the stream-sea JWT that is:
 	  - signed using the client JWT public key with the RS512 algorithm
-		- serialized to a string using RFC 7515 JWS Compact Serialization
+    - serialized to a string using RFC 7515 JWS Compact Serialization
 - The server must respond to an Authentication Request message with exactly one Authentication Response message
 
 ### Stream-sea JWT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-sea-client",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Require RS512 algorithm for JWT.
This is a non-backwards-compatible change